### PR TITLE
Kill slaves if master dies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
 
-RUN apk --no-cache add curl dumb-init git openssh-client bash
+RUN apk --no-cache add curl dumb-init git openssh-client bash jq
 
 #Install Docker
 RUN apk --no-cache add shadow su-exec docker

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -70,8 +70,10 @@ jenkins_cli get-node "$JENKINS_SLAVE_NAME" &>/dev/null || {
 }
 
 # run slave
-su $JENKINS_USER - -c \
-    "java $JAVA_OPTS -jar '$DOWNLOAD_DIR/slave.jar' -jnlpCredentials '$JENKINS_AUTH' -jnlpUrl '$JENKINS_URL/computer/$JENKINS_SLAVE_NAME/slave-agent.jnlp'"
+( su $JENKINS_USER - -c \
+  "java $JAVA_OPTS -jar '$DOWNLOAD_DIR/slave.jar' -jnlpCredentials '$JENKINS_AUTH' -jnlpUrl '$JENKINS_URL/computer/$JENKINS_SLAVE_NAME/slave-agent.jnlp'" ) &
+
+while curl -svm 5 "$JENKINS_URL" > /dev/null; do sleep 30; done
 
 # exit gracefully
 exit 0


### PR DESCRIPTION
This adds a loop that checks for the master every 30s. The reason for this is that if the master dies the slaves dont re-register. They get 401 as they expect a master which already knows about them.

I've also added jq as this is a useful tool and required by some of our dev teams.