### PR TITLE
Remove connectivity test so k8s probes can be used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-releas
 #Install aws cli and azure cli
 RUN apk --no-cache add su-exec docker groff python py-pip gettext procps && \
     apk --no-cache add --virtual=build gcc libffi-dev musl-dev openssl-dev python-dev python3-dev make && \
+    pip install --upgrade pip==18.0 && \
     pip install awscli s3cmd azure-cli && \
     apk del --purge build
 

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -73,7 +73,3 @@ jenkins_cli get-node "$JENKINS_SLAVE_NAME" &>/dev/null || {
 ( su $JENKINS_USER - -c \
   "java $JAVA_OPTS -jar '$DOWNLOAD_DIR/slave.jar' -jnlpCredentials '$JENKINS_AUTH' -jnlpUrl '$JENKINS_URL/computer/$JENKINS_SLAVE_NAME/slave-agent.jnlp'" ) &
 
-while curl -svm 5 "$JENKINS_URL" > /dev/null; do sleep 30; done
-
-# exit gracefully
-exit 0


### PR DESCRIPTION
We have found the connectivity test to be too aggressive as it kills the slave on the first instance of a connectivity failure. In Azure we are seeing frequent network blips which results in slaves terminating and builds failing intermittently. We would instead like to manage the lifecycle of the slaves through kubernetes liveness probes.